### PR TITLE
Fix toast listener and topic box type

### DIFF
--- a/dify-like-ui.tsx
+++ b/dify-like-ui.tsx
@@ -60,7 +60,7 @@ const DifyLikeUI: React.FC<DifyLikeUIProps> = ({ selectedType, onReset }) => {
     setTopicBoxes(prevTopicBoxes => [...prevTopicBoxes, newTopicBox])
   }, [topicBoxes])
 
-  const handleTopicBoxDrag = useCallback((id: number, newPosition: { x: number, y: number }) => {
+  const handleTopicBoxDrag = useCallback((id: string, newPosition: { x: number, y: number }) => {
     setTopicBoxes(prevTopicBoxes =>
       prevTopicBoxes.map(box =>
         box.id === id

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix `useToast` effect dependencies to avoid duplicated listeners
- correct `handleTopicBoxDrag` id type

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68402b92bb40832ab0ac9ffc53650322