### PR TITLE
Add multi category chat selector

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,9 @@
-import MBTICircleSelector from '../mbti-circle-selector'
+import ChatEntrance from '../chat-entrance'
 
 export default function Home() {
   return (
     <main>
-      <MBTICircleSelector />
+      <ChatEntrance />
     </main>
   )
 }

--- a/chat-entrance.tsx
+++ b/chat-entrance.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useState } from 'react'
+import MBTICircleSelector from './mbti-circle-selector'
+import SimpleTypeSelector from './simple-type-selector'
+import { chatGroups, ChatGroup, ChatType } from './utils/chat-categories'
+import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { DifyLikeUI } from './dify-like-ui'
+
+export default function ChatEntrance() {
+  const [group, setGroup] = useState<ChatGroup | null>(null)
+  const [type, setType] = useState<ChatType | null>(null)
+
+  const resetAll = () => {
+    setGroup(null)
+    setType(null)
+  }
+
+  if (!group) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-50 to-slate-200 p-4">
+        <h1 className="text-4xl font-bold mb-8" style={{ fontFamily: "'Bebas Neue', cursive" }}>カテゴリを選択</h1>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 w-full max-w-3xl">
+          {chatGroups.map(g => (
+            <Card
+              key={g.id}
+              onClick={() => setGroup(g)}
+              className="cursor-pointer hover:scale-105 transition"
+              style={{ backgroundColor: g.color, color: g.textColor, fontFamily: g.font }}
+            >
+              <CardHeader>
+                <CardTitle>{g.name}</CardTitle>
+                <CardDescription className="opacity-80">{g.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (group.id === 'mbti') {
+    return <MBTICircleSelector onExit={resetAll} />
+  }
+
+  if (type) {
+    return <DifyLikeUI selectedType={type} onReset={resetAll} />
+  }
+
+  return <SimpleTypeSelector group={group} onSelect={setType} onBack={() => setGroup(null)} />
+}

--- a/dify-like-ui.tsx
+++ b/dify-like-ui.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react'
 import { nanoid } from 'nanoid'
-import { MBTIType } from './utils/mbti'
+import { ChatType } from './utils/chat-categories'
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { AIInputWithFile } from '@/components/ui/ai-input-with-file'
@@ -17,7 +17,7 @@ interface TopicBox {
 }
 
 interface DifyLikeUIProps {
-  selectedType: MBTIType
+  selectedType: ChatType
   onReset: () => void
 }
 

--- a/mbti-circle-selector.tsx
+++ b/mbti-circle-selector.tsx
@@ -6,7 +6,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { DifyLikeUI } from './dify-like-ui'
 
-export default function MBTICircleSelector() {
+interface MBTICircleSelectorProps {
+  onExit?: () => void
+}
+export default function MBTICircleSelector({ onExit }: MBTICircleSelectorProps) {
   const [selectedCategory, setSelectedCategory] = useState<MBTICategory | null>(null)
   const [selectedType, setSelectedType] = useState<MBTIType | null>(null)
   const [hoveredCategory, setHoveredCategory] = useState<string | null>(null)
@@ -115,7 +118,12 @@ export default function MBTICircleSelector() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto px-4 py-8 relative">
+      {onExit && (
+        <Button onClick={onExit} variant="ghost" className="absolute top-4 left-4">
+          戻る
+        </Button>
+      )}
       <h1 className="text-4xl font-bold text-center mb-8" style={{ fontFamily: "'Bebas Neue', cursive" }}>あなたのMBTIタイプを調べましょう</h1>
       
       {selectedType ? (

--- a/simple-type-selector.tsx
+++ b/simple-type-selector.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { ChatGroup, TypeOption } from './utils/chat-categories'
+import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  group: ChatGroup
+  onSelect: (type: TypeOption) => void
+  onBack: () => void
+}
+
+export default function SimpleTypeSelector({ group, onSelect, onBack }: Props) {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <Button onClick={onBack} variant="ghost" className="mb-4">戻る</Button>
+      <h2 className="text-3xl font-bold text-center mb-8" style={{ fontFamily: group.font }}>
+        {group.name}
+      </h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {group.types.map((t) => (
+          <Card
+            key={t.code}
+            onClick={() => onSelect(t)}
+            className="cursor-pointer hover:shadow-lg transition p-4 text-center"
+            style={{ backgroundColor: group.color, color: group.textColor, fontFamily: group.font }}
+          >
+            <CardHeader className="p-2">
+              <CardTitle className="text-xl">{t.name}</CardTitle>
+              {t.description && (
+                <CardDescription className="text-sm opacity-80">{t.description}</CardDescription>
+              )}
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/utils/chat-categories.ts
+++ b/utils/chat-categories.ts
@@ -1,0 +1,93 @@
+import { mbtiCategories } from './mbti'
+
+export interface TypeOption {
+  code: string
+  name: string
+  description?: string
+}
+
+export interface ChatGroup {
+  id: string
+  name: string
+  description: string
+  color: string
+  textColor: string
+  font: string
+  types: TypeOption[]
+}
+
+export const chatGroups: ChatGroup[] = [
+  {
+    id: 'mbti',
+    name: 'MBTI',
+    description: '16タイプの性格分類',
+    color: '#FF6B6B',
+    textColor: '#FFFFFF',
+    font: "'Bebas Neue', cursive",
+    types: mbtiCategories.flatMap(c => c.types),
+  },
+  {
+    id: 'blood',
+    name: '血液型',
+    description: 'A/B/O/AB で交流',
+    color: '#F87171',
+    textColor: '#FFFFFF',
+    font: "'Noto Sans JP', sans-serif",
+    types: [
+      { code: 'A', name: 'A型', description: '几帳面で協調的とされることが多い' },
+      { code: 'B', name: 'B型', description: 'マイペースで好奇心旺盛' },
+      { code: 'O', name: 'O型', description: '社交的でおおらか' },
+      { code: 'AB', name: 'AB型', description: '独創的で二面性があるとされる' },
+    ],
+  },
+  {
+    id: 'gender',
+    name: 'Gender',
+    description: '性別別チャット',
+    color: '#60A5FA',
+    textColor: '#FFFFFF',
+    font: "'Roboto', sans-serif",
+    types: [
+      { code: 'male', name: '男性' },
+      { code: 'female', name: '女性' },
+      { code: 'other', name: 'その他' },
+    ],
+  },
+  {
+    id: 'intro_extro',
+    name: '陰キャ/陽キャ',
+    description: '気質で交流',
+    color: '#A78BFA',
+    textColor: '#FFFFFF',
+    font: "'Oswald', sans-serif",
+    types: [
+      { code: 'introvert', name: '陰キャ' },
+      { code: 'extrovert', name: '陽キャ' },
+    ],
+  },
+  {
+    id: 'birth_month',
+    name: '誕生月',
+    description: '月ごとのルーム',
+    color: '#34D399',
+    textColor: '#FFFFFF',
+    font: "'Noto Sans JP', sans-serif",
+    types: [
+      { code: '1', name: '1月' },
+      { code: '2', name: '2月' },
+      { code: '3', name: '3月' },
+      { code: '4', name: '4月' },
+      { code: '5', name: '5月' },
+      { code: '6', name: '6月' },
+      { code: '7', name: '7月' },
+      { code: '8', name: '8月' },
+      { code: '9', name: '9月' },
+      { code: '10', name: '10月' },
+      { code: '11', name: '11月' },
+      { code: '12', name: '12月' },
+    ],
+  },
+]
+
+export type ChatGroupId = typeof chatGroups[number]['id']
+export type ChatType = TypeOption


### PR DESCRIPTION
## Summary
- support multiple chat classifications
- implement simple type selector and an entrance page
- allow returning from MBTI view
- generalize Dify-like UI props

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840339453f8832a8da77df15147c6a9